### PR TITLE
Episode Number now pre-filled

### DIFF
--- a/cubfan135/index.html
+++ b/cubfan135/index.html
@@ -30,8 +30,8 @@
         </div>
 
         <a class="button secondary" style="text-decoration: none; margin: 20px" href="#" id="downloader" onclick="finishEditing()" download="image.png"><i class="material-icons md-18">get_app</i>Download Thumbnail</a>
+        <input id="set-cookie" type="button">
     </form>
-
     <script src="./script.js"></script>
 </body>
 

--- a/cubfan135/script.js
+++ b/cubfan135/script.js
@@ -1,12 +1,9 @@
 const bgInput = document.getElementById('bgInput');
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
-//const getImage = document.getElementById('getImage');
 const epNumSelector = document.getElementById('epNumSelector');
 const hcLogoToggler = document.getElementById('hcLogoToggler');
 const previewText = document.getElementById('preview-text');
-
-//getImage.addEventListener('click', finishEditing.bind())
 
 function editOnCanvas() {
     let bgImage = new Image();
@@ -59,3 +56,15 @@ function process() {
         episodeNum();
     }
 }
+//Cookies stuff start here
+document.getElementById('set-cookie').addEventListener('click', () => {
+    console.log(`setting cookies started`);
+    document.cookie = "epNumCookie=2";
+    console.log(`setting cookies done`);
+    console.log(document.cookie);
+    
+    //const preepNumCookie = document.cookie.split('=');
+    //const epNumCookie = preepNumCookie[1].split(';');
+    //console.log(preepNumCookie);
+    //console.log(epNumCookie[0]);
+})

--- a/cubfan135/script.js
+++ b/cubfan135/script.js
@@ -56,15 +56,16 @@ function process() {
         episodeNum();
     }
 }
-//Cookies stuff start here
-document.getElementById('set-cookie').addEventListener('click', () => {
-    console.log(`setting cookies started`);
-    document.cookie = "epNumCookie=2";
-    console.log(`setting cookies done`);
-    console.log(document.cookie);
-    
-    //const preepNumCookie = document.cookie.split('=');
-    //const epNumCookie = preepNumCookie[1].split(';');
-    //console.log(preepNumCookie);
-    //console.log(epNumCookie[0]);
-})
+//cookies stuff
+let epNumValueFromCookie;
+
+downloader.addEventListener("click", () => {
+  document.cookie = `epNumCookie=${epNumSelector.value}`;
+});
+
+if (document.cookie.length === 0) {
+  epNumValueFromCookie = "";
+} else {
+  epNumValueFromCookie = document.cookie.split("=")[1];
+  epNumSelector.value = Number(epNumValueFromCookie) + 1;
+}


### PR DESCRIPTION
epNumSelector is now filled automatically based on the user's last filled value.
Example: User opens the webpage, fills episode number '28', and downloads the thumbnail. Next time when the user visits, episode number will be automatically filled with '29'. This trend continues on forever until the user deletes its cookies.