### PR TITLE
Fixed #27 making the label element receive focus

### DIFF
--- a/Source/cubfan135/index.html
+++ b/Source/cubfan135/index.html
@@ -27,33 +27,41 @@
 <body>
   <section id="preview-area">
     <div id="preview-text"><i class="material-icons-outlined">remove_red_eye</i> Preview</div>
-    <canvas width="1920" height="1080" id="canvas">Your browser does not support the canvas element. Consider upgrading to a newer browser.</canvas>
+    <canvas width="1920" height="1080" id="canvas">Your browser does not support the canvas element. Consider upgrading
+      to a newer browser.</canvas>
   </section>
 
   <main id="form">
     <span id="bgArea">
-      <label class="area" id="bgInputLabel" for="bgInput" title="Choose background image or nothing."><i class="material-icons-outlined">publish</i> Choose Background</label>
-      <button class="area" title="Removed background image" onclick="javascript: bgInput.value = ''; process()"><i class="material-icons-outlined">close</i></button>
+      <label class="area" id="bgInputLabel" for="bgInput" title="Choose background image or nothing."
+       role="button" tabindex="0"><i class="material-icons-outlined">publish</i> Choose Background</label>
+      <button class="area" title="Removed background image" onclick="javascript: bgInput.value = ''; process()"><i
+          class="material-icons-outlined">close</i></button>
       <input type="file" accept="image/*" onchange="process()" id="bgInput">
     </span>
 
     <input class="area" type="text" title="Enter episode number here. It can accept number, text or nothing."
-      oninput="process()" onclick="this.focus();this.select();" id="epNumSelector" placeholder="Enter Episode Number" autocomplete="off">
+      oninput="process()" onclick="this.focus();this.select();" id="epNumSelector" placeholder="Enter Episode Number"
+      autocomplete="off">
 
     <span class="area" id="show-hc-logo" style="cursor: auto;">
       <label for="hcLogoToggler" style="cursor: pointer;">Show HC7 Logo:</label>
       <input type="checkbox" checked onchange="process()" id="hcLogoToggler" class="mdc-switch">
     </span>
 
-    <a class="area" style="text-decoration: none;" href="#" id="downloader" onclick="finishEditing()" download="image.png">
+    <a class="area" style="text-decoration: none;" href="#" id="downloader" onclick="finishEditing()"
+      download="image.png">
       <i class="material-icons-outlined">get_app</i>Download Thumbnail</a>
 
     <span id="etc">
-      <button class="area" title="Check out the repository" onclick="javascript: window.location = 'https://github.com/hermit-tools/Thumbnail-Maker'">
+      <button class="area" title="Check out the repository"
+        onclick="javascript: window.location = 'https://github.com/hermit-tools/Thumbnail-Maker'">
         <i class="material-icons-outlined">info</i></button>
-      <button class="area" title="Share Cub's Contraption" onclick="javascript: navigator.share({title: `Cub's Contraption by Hermit Tools`, url: ''})">
+      <button class="area" title="Share Cub's Contraption"
+        onclick="javascript: navigator.share({title: `Cub's Contraption by Hermit Tools`, url: ''})">
         <i class="material-icons-outlined">share</i></button>
-      <button class="area" title="Clear canvas and start over" onclick="ctx.clearRect(0, 0, canvas.width, canvas.height)">
+      <button class="area" title="Clear canvas and start over"
+        onclick="ctx.clearRect(0, 0, canvas.width, canvas.height)">
         <i class="material-icons-outlined">backspace</i></button>
     </span>
   </main>

--- a/Source/cubfan135/script.js
+++ b/Source/cubfan135/script.js
@@ -1,4 +1,5 @@
 const bgInput = document.getElementById("bgInput");
+const bgInputLabel = document.getElementById("bgInputLabel");
 const epNumSelector = document.getElementById("epNumSelector");
 const hcLogoToggler = document.getElementById("hcLogoToggler");
 
@@ -11,6 +12,19 @@ const hc7Logo = new Image();
 hc7Logo.src =
   "https://hermit-tools.github.io/Thumbnail-Maker/Resources/Hermitcraft Logos/HC7 Logo.png";
 hc7Logo.crossOrigin = "Anonymous";
+
+//Focus Choose Background Label
+bgInputLabel.addEventListener("focus", e => {
+  e.preventDefault();
+});
+
+//Make Label Interactive
+bgInputLabel.addEventListener("keydown", e => {
+  if (e.key = 32) {
+    bgInput.click();
+  }
+});
+
 
 // Cookies Stuff
 downloader.addEventListener("click", () => {


### PR DESCRIPTION
Issue: The label "Choose Background" was not focusable.

Resolution: I studied the reason the label was not focusable even with adding the attribute tabindex=0. I discovered from my research that it was because label elements have a default behaviour of passing the focus to the input element they label. So, my solution was to prevent that default behaviour using javascript. After preventing the default behaviour I added tabindex attribute and the label received focus without passing it on.
At this point, I have solved this issue you opened. However, the element still had other keyboard accessibility problems. For example, it did not have interactive semantics. For that I changed the role of the element to button using the role attribute. There was finally, the problem of interactivity. So, again I used javascript to add interactivity by adding the keyboard keydown event to the label element so that it can call the click method on the input button.