### PR TITLE
added feature to switch to dark/light mode based on user's preferred mode

### DIFF
--- a/cubfan135/index.html
+++ b/cubfan135/index.html
@@ -24,8 +24,8 @@
   <meta property="og:url" content="https://hermit-tools.github.io/Thumbnail-Maker/cubfan135" />
 </head>
 
-<body>
-  <div id="preview-area">
+<body class="day night">
+  <div id="preview-area" >
     <div id="preview-text">
       <i class="material-icons md-48">remove_red_eye</i>Preview
     </div>

--- a/cubfan135/style.css
+++ b/cubfan135/style.css
@@ -2,6 +2,14 @@ html {
   height: 100%;
 }
 
+@media (prefers-color-scheme: dark) {
+  .night { background: #333; }
+}
+
+@media (prefers-color-scheme: light) {
+  .day { background: #ffffff; color: black; }
+}
+
 body {
   display: grid;
   grid-template-columns: 70% 30%;


### PR DESCRIPTION
#23 
the webpage currently looks like :

light mode:
![Screenshot (135)](https://user-images.githubusercontent.com/58389098/95672298-42a89100-0bbd-11eb-9991-c90e6d548479.png)

dark mode:
![Screenshot (134)](https://user-images.githubusercontent.com/58389098/95672302-4f2ce980-0bbd-11eb-889d-fdb1c8379eb2.png)

Feel free to suggest changes , if any. 
:)
