### PR TITLE
 Labeled the canvas element for accessibility improvements

### DIFF
--- a/Source/cubfan135/index.html
+++ b/Source/cubfan135/index.html
@@ -30,7 +30,7 @@
       <i class="material-icons-outlined">remove_red_eye</i> Preview
     </div>
     
-    <canvas width="1920" height="1080" id="canvas">
+    <canvas width="1920" height="1080" id="canvas" aria-label="A preview area of your thumbnail">
       Your browser does not support the canvas element. Consider upgrading to a newer browser.
     </canvas>
   </section>


### PR DESCRIPTION
Issue:
The firefox accessibility inspector tools flagged the canvas element with this message "Content with images must be labeled". This is basically saying that a descriptive text should be provided for the canvas element for better assistive technology user-experience.

Solution:
I added the aria-label attribute to the canvas element and gave it the value "A preview area of your thumbnail", hoping that would be an appropriate description for that element.