### PR TITLE
Fixed #18 Removed animations by adding prefers-reduced-motion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,16 @@
 The following is a set of guidelines for contributing to Thumbnail-Maker. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 ## Submitting a change
-Please commit all the changes in the beta version of the tool only. Beta version of anything is located under *Source/* with the same rest of the location. Commiting to the direct next release is more beneficial than commiting to a far release.  
-Please send a GitHub Pull Request with a clear list of what you've done. Please make sure all of your commits are atomic (one feature per commit).
-
-Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
+- Please commit all the changes in the beta version of the tool only. Beta version of anything is located under *Source/* with the same rest of the location. Commiting to the direct next release is more beneficial than commiting to a far release.  
+- Please send a GitHub Pull Request with a clear list of what you've done. Please make sure all of your commits are atomic (one feature per commit).
+- We don't and do not plan to use ANY external framework. So submit your code in plain JavaScript only.
+- Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 ```
 $ git commit -m "A brief summary of the commit
 > 
 > A paragraph describing what changed and its impact."
 ```
-We would love if you add emojis to your commit messages. Emojis can make commit messages very much friendly. The following is a table of emojis you can add with your commit messages. Feel free to add more rows to the table.
+- We would love if you add emojis to your commit messages. Emojis can make commit messages very much friendly. The following is a table of emojis you can add with your commit messages. Feel free to add more rows to the table.
 
 Commit is about | Emoji to represent | Example
 --- | --- | ---
@@ -30,3 +30,4 @@ Start reading our code and you'll get the hang of it. We optimize for readabilit
 - We indent using four spaces
 - We ALWAYS put spaces after list items and method parameters ([1, 2, 3], not [1,2,3]), around operators (x += 1, not x+=1), and around hash arrows.
 - This is open source software. Consider the people who will read your code, and make it look nice for them. It's sort of like driving a car: Perhaps you love doing donuts when you're alone, but with passengers the goal is to make the ride as smooth as possible.
+- We do not use any external JavaScript framework.

--- a/Source/cubfan135/style.css
+++ b/Source/cubfan135/style.css
@@ -349,7 +349,6 @@ body.dark .area::placeholder {
   }
 
   /* style for the .area class elements except the download button */
-  .area:active:not(#downloader),
   .area:hover:not(#downloader) {
     border-color: #0032d6 !important;
     color: #0032d6 !important;

--- a/Source/cubfan135/style.css
+++ b/Source/cubfan135/style.css
@@ -1,6 +1,6 @@
 html {
   height: 100%;
-  --themeColor: #037de1;
+  --themeColor: #0576DF;
 }
 
 body {
@@ -80,7 +80,7 @@ input[type="file"] {
   width: 640px;
   height: 360px;
   background: #fff;
-  color: #c7e3ff;
+  color: #949594;
   border-radius: 5px;
   font-size: 48px;
   font-weight: 900;

--- a/Source/cubfan135/style.css
+++ b/Source/cubfan135/style.css
@@ -341,3 +341,17 @@ body.dark .area::placeholder {
   filter: sepia(180%);
   outline: none;
 }
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .area:active,
+  .area:hover{
+    transform: none !important;
+  }
+
+  /* style for the .area class elements except the download button */
+  .area:active:not(#downloader),
+  .area:hover:not(#downloader) {
+    border-color: #0032d6 !important;
+    color: #0032d6 !important;
+  }
+}


### PR DESCRIPTION
This pull request fixes #18 

I have added a new media query (prefers-reduced-motion: reduce) and inside it I removed all transition effects using the universal selector. There are no animation properties in the code, so I wrote only `transition: none`  for a cleaner code. I use a windows 10 pc and turned off SHOW ANIMATIONS IN WINDOWS and tested the code. The transition effects were disabled but were enabled when I turned it back on. The transform properties such as scale are still active, though as they are not within the scope of animations. 

In the css declaration under the prefers-reduced-motion, I used the `!important` keyword to give this rule the highest specificity because media queries have no specificity while the universal selector * has low specificity. The code would not work otherwise.